### PR TITLE
Fix Issue MM-257, invalid scopes during /gitlab connect

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -119,7 +119,7 @@ func (p *Plugin) OnActivate() error {
 func (p *Plugin) getOAuthConfig() *oauth2.Config {
 	config := p.getConfiguration()
 
-	scopes := []string{"api", "read_user"}
+	scopes := []string{}
 	redirectURL := fmt.Sprintf("%s/plugins/%s/oauth/complete", *p.API.GetConfig().ServiceSettings.SiteURL, manifest.ID)
 
 	if config.UsePreregisteredApplication {


### PR DESCRIPTION
This PR is fixing bug in [Issue 257](https://github.com/mattermost/mattermost-plugin-gitlab/issues/257)

The problem with the error **The requested scope is invalid, unknown, or malformed** is caused by more scopes being selected in the Mattermost plugin gitlab than in the gitlab.

the changed code is in the 'server/plugin.go' file. Precisely changing scopes which were originally "api" & "read_user" to empty array string.
Then when `/gitlab connect` is tried it shows connected successfully.

When selecting a scope other than "api", for example choosing "profile" only without 'API'. The gitlab server sends the error **The requested scope is invalid, unknown, or malformed**.
The above situation can be concluded that the gitlab server will send the same error if it does not check 'api'.